### PR TITLE
Removed duplicated declaration of content type multipart

### DIFF
--- a/drop_server.py
+++ b/drop_server.py
@@ -91,7 +91,6 @@ def send_multipart(records, start_response):
     start_response('200 OK', [('Content-Type',
                                'multipart/mixed; boundary="' + boundary + '"')])
     ret = []
-    ret.append('Content-Type: multipart/mixed; boundary="' + boundary + '"\r\n')
 
     ret.append('\r\n')
     for timestamp, message in records:      


### PR DESCRIPTION
The second content type has been introduced because of the erroneous
assumption, that the content type declaration in the start_response
call gets lost. But it isn't. Instead the problem is with the client's
parser client.

You should probably wait with merging this commit until the bug in the client's parser has been fixed.

Related to Qabel/qabel-core#117

Contributes to #11 
