### PR TITLE
Updated maximum drop message size to current transport format version 0

### DIFF
--- a/drop_server.py
+++ b/drop_server.py
@@ -49,7 +49,7 @@ from cgi import parse_header, parse_multipart
 from Crypto import Random
 
 MESSAGES_PER_DROP_LIMIT = 10
-MESSAGE_SIZE_LIMIT = 2000  # Octets
+MESSAGE_SIZE_LIMIT = 2573  # Octets
 MESSAGE_EXPIRE_TIME = 60 * 60 * 24 * 7  # Seconds
 
 

--- a/drop_server.py
+++ b/drop_server.py
@@ -49,6 +49,9 @@ from cgi import parse_header, parse_multipart
 from Crypto import Random
 
 MESSAGES_PER_DROP_LIMIT = 10
+# Total binary message size
+# comprises header, key, payload (2KB), signature
+# see https://github.com/Qabel/qabel-doc/wiki/Qabel-Client-Drop#transport-format
 MESSAGE_SIZE_LIMIT = 2573  # Octets
 MESSAGE_EXPIRE_TIME = 60 * 60 * 24 * 7  # Seconds
 


### PR DESCRIPTION
Maximum drop message size is too small for the current binary drop message version 0.