### PR TITLE
Remove nested virtualenv and travis_wait

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,8 @@ install:
  - git submodule update --depth 1
  - rm -rf qabel-drop
  - mv ../qabel-drop ./
- - virtualenv qabel-drop 
- - source qabel-drop/bin/activate 
  - pip install -r qabel-drop/requirements.txt 
 # command to run tests
 script:
  - nosetests
- - travis_wait ./gradlew check
+ - ./gradlew check


### PR DESCRIPTION
Fix up the travis config, so we don't created nested virtualenvs.

This also removes the travis_wait call because it is simply not needed anymore.