### PR TITLE
 	Add proprietary high-resolution "If-Modified-Since"

### DIFF
--- a/drop_service/util.py
+++ b/drop_service/util.py
@@ -1,5 +1,6 @@
 
 import base64
+import datetime
 import re
 
 
@@ -18,3 +19,8 @@ def check_drop_id(drop_id):
 
 def set_last_modified(response, modification_date):
     response['Last-Modified'] = modification_date.strftime("%a, %d %b %Y %H:%M:%S GMT")
+
+
+def utc_timestamp(datetime_obj):
+    """Return float UTC timestamp for *datetime_obj*."""
+    return datetime_obj.replace(tzinfo=datetime.timezone.utc).timestamp()

--- a/drop_service/views.py
+++ b/drop_service/views.py
@@ -1,4 +1,5 @@
 
+import datetime
 import json
 import uuid
 from email.utils import formatdate
@@ -16,7 +17,7 @@ from rest_framework import status
 
 from . import monitoring
 from .models import Drop
-from .util import check_drop_id, set_last_modified
+from .util import check_drop_id, set_last_modified, utc_timestamp
 
 
 def error(msg, status=status.HTTP_400_BAD_REQUEST):
@@ -39,11 +40,15 @@ class DropView(View):
         if not drops:
             return HttpResponse(status=status.HTTP_204_NO_CONTENT), None
 
-        have_since, since = self.get_if_modified_since()
+        try:
+            have_since, since = self.get_if_modified_since()
+        except ValueError as value_error:
+            return error(str(value_error)), None
+
         if have_since:
             drops = drops.filter(created_at__gt=since)
-            if not drops:
-                return HttpResponseNotModified(), None
+        if have_since and not drops:
+            return HttpResponseNotModified(), None
 
         return None, drops
 
@@ -58,7 +63,7 @@ class DropView(View):
         body = self.generate_body(drops, boundary)
         response = HttpResponse(body, content_type=content_type)
         if drops:
-            set_last_modified(response, drops.latest().created_at)
+            self.set_latest(response, drops.latest())
         return response
 
     def head(self, request, drop_id):
@@ -83,11 +88,21 @@ class DropView(View):
         return HttpResponse()
 
     def get_if_modified_since(self):
-        since = self.request.META.get('HTTP_IF_MODIFIED_SINCE')
-        if since:
-            return True, dateparser.parse(since)
+        coarse_since = self.request.META.get('HTTP_IF_MODIFIED_SINCE')
+        finest_since = self.request.META.get('HTTP_X_QABEL_NEW_SINCE')
+        if coarse_since and finest_since:
+            raise ValueError('Specify only one of X-Qabel-New-Since, If-Modified-Since')
+        if coarse_since:
+            return True, dateparser.parse(coarse_since)
+        elif finest_since:
+            return True, datetime.datetime.fromtimestamp(float(finest_since), datetime.timezone.utc)
         else:
             return False, None
+
+    def set_latest(self, response, latest_drop):
+        set_last_modified(response, latest_drop.created_at)
+        timestamp = utc_timestamp(latest_drop.created_at)
+        response['X-Qabel-Latest'] = str(timestamp)
 
     @staticmethod
     def generate_body(drops, boundary):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,13 @@
+
+
+from drop_service.models import Drop
+from drop_service.util import utc_timestamp
+
+
+def test_time_granularity(db):
+    a = Drop(drop_id='abcdefghijklmnopqrstuvwxyzabcdefghijklmnfoo', message=b"Bar")
+    a.save()
+    b = Drop(drop_id='abcdefghijklmnopqrstuvwxyzabcdefghijklmnopo', message=b"Hello World")
+    b.save()
+    dt = utc_timestamp(b.created_at) - utc_timestamp(a.created_at)
+    assert dt > 0

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -10,6 +10,7 @@ from rest_framework import status
 import pytz
 
 from drop_service.models import Drop
+from drop_service.util import utc_timestamp
 
 
 def err(body: bytes):
@@ -20,11 +21,11 @@ class DropServerTestCase(TestCase):
     def setUp(self):
         """Pre-test activities."""
         self.app = Client()
-        drop = Drop(drop_id='abcdefghijklmnopqrstuvwxyzabcdefghijklmnopo', message=b"Hello World")
-        dropfoo = Drop(drop_id='abcdefghijklmnopqrstuvwxyzabcdefghijklmnfoo', message=b"Bar")
-        dropfoo.created_at = datetime.datetime(year=2016, month=1, day=1, tzinfo=pytz.UTC)
-        drop.save()
-        dropfoo.save()
+        self.drop = Drop(drop_id='abcdefghijklmnopqrstuvwxyzabcdefghijklmnopo', message=b"Hello World")
+        self.dropfoo = Drop(drop_id='abcdefghijklmnopqrstuvwxyzabcdefghijklmnfoo', message=b"Bar")
+        self.dropfoo.created_at = datetime.datetime(year=2016, month=1, day=1, tzinfo=pytz.UTC)
+        self.drop.save()
+        self.dropfoo.save()
 
     #######GET
     def test_get_message_from_invalid_drop_id(self):
@@ -40,9 +41,10 @@ class DropServerTestCase(TestCase):
         assert response.content.decode().count("Hello World") == 1
         assert 'Bar' not in response.content.decode()
 
-    def test_get_messsages_contains_last_modified_header(self):
+    def test_get_messsages_contains_headers(self):
         response = self.app.get('/abcdefghijklmnopqrstuvwxyzabcdefghijklmnfoo')
         assert response['Last-Modified'] == "Fri, 01 Jan 2016 00:00:00 GMT"
+        assert 'X-Qabel-Latest' in response
 
     def test_get_messages_empty_drop(self):
         response = self.app.get('/abcdefghijklmnopqrstuvwxyzabcdefghijklempty')
@@ -55,8 +57,24 @@ class DropServerTestCase(TestCase):
                                 HTTP_IF_MODIFIED_SINCE=format_datetime(dt, usegmt=True))
 
         assert response.status_code == status.HTTP_200_OK
-        print(response.content.decode())
         assert 'Hello World' in response.content.decode()
+
+    def test_get_messages_posted_since_qabel(self):
+        response = self.app.get('/abcdefghijklmnopqrstuvwxyzabcdefghijklmnopo',
+                                HTTP_X_QABEL_NEW_SINCE=str(utc_timestamp(self.dropfoo.created_at)))
+
+        assert response.status_code == status.HTTP_200_OK
+        body = response.content.decode()
+        assert 'Hello World' in body
+        assert 'Bar' not in body
+
+    def test_get_qabel_round_trip(self):
+        response = self.app.get('/abcdefghijklmnopqrstuvwxyzabcdefghijklmnopo')
+        assert response.status_code == status.HTTP_200_OK
+        latest = response['X-Qabel-Latest']
+        response = self.app.get('/abcdefghijklmnopqrstuvwxyzabcdefghijklmnopo',
+                                HTTP_X_QABEL_NEW_SINCE=latest)
+        assert response.status_code == status.HTTP_304_NOT_MODIFIED
 
     def test_get_messages_posted_since_gmt1(self):
         dt = datetime.datetime.now(tz=pytz.timezone('Europe/Berlin')) - datetime.timedelta(minutes=1)
@@ -64,13 +82,18 @@ class DropServerTestCase(TestCase):
                                 HTTP_IF_MODIFIED_SINCE=format_datetime(dt))
 
         assert response.status_code == status.HTTP_200_OK
-        print(response.content.decode())
         assert 'Hello World' in response.content.decode()
 
     def test_get_no_messages_posted_since(self):
         dt = datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(minutes=1)
         response = self.app.get('/abcdefghijklmnopqrstuvwxyzabcdefghijklmnopo',
                                 HTTP_IF_MODIFIED_SINCE=format_datetime(dt, usegmt=True))
+        assert response.status_code == status.HTTP_304_NOT_MODIFIED
+        assert response.content == b''
+
+    def test_get_no_messages_posted_since_qabel(self):
+        response = self.app.get('/abcdefghijklmnopqrstuvwxyzabcdefghijklmnopo',
+                                HTTP_X_QABEL_NEW_SINCE=str(utc_timestamp(self.drop.created_at) + 1))
         assert response.status_code == status.HTTP_304_NOT_MODIFIED
         assert response.content == b''
 
@@ -106,10 +129,22 @@ class DropServerTestCase(TestCase):
         assert response.status_code == status.HTTP_200_OK
         assert response.content == b''
 
+    def test_head_messages_posted_since_qabel(self):
+        response = self.app.head('/abcdefghijklmnopqrstuvwxyzabcdefghijklmnopo',
+                                 HTTP_X_QABEL_NEW_SINCE=str(utc_timestamp(self.dropfoo.created_at)))
+        assert response.status_code == status.HTTP_200_OK
+        assert response.content == b''
+
     def test_head_no_messages_posted_since(self):
         dt = datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(minutes=1)
         response = self.app.head('/abcdefghijklmnopqrstuvwxyzabcdefghijklmnopo',
                                  HTTP_IF_MODIFIED_SINCE=format_datetime(dt, usegmt=True))
+        assert response.status_code == status.HTTP_304_NOT_MODIFIED
+        assert response.content == b''
+
+    def test_head_no_messages_posted_since_etag(self):
+        response = self.app.head('/abcdefghijklmnopqrstuvwxyzabcdefghijklmnopo',
+                                 HTTP_X_QABEL_NEW_SINCE=str(utc_timestamp(self.drop.created_at) + 1))
         assert response.status_code == status.HTTP_304_NOT_MODIFIED
         assert response.content == b''
 


### PR DESCRIPTION
If this is no problem library-wise it may be better if we'd maybe use a proprietary header here? Because this isn't exactly the ETag ("nothing or everything") semantics, which aren't very useful for us here anyway. We just want last-modified without the problems of last-modified. `X-Qabel-Etag-Since`? Could also just stick with this.