### PR TITLE
Remove message from body due to length limits

### DIFF
--- a/drop_service/notify.py
+++ b/drop_service/notify.py
@@ -41,7 +41,7 @@ class FCM:
     def _notify(self, drop):
         data = {
             'drop-id': drop.drop_id,
-            'message': base64.b64encode(drop.message).decode(),
+        #    'message': base64.b64encode(drop.message).decode(),
         }
         # Alphabet of topics: [a-zA-Z0-9-_.~%]
         # Alphabet of drop IDs: [a-zA-Z0-9-_]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ djangorestframework==3.3.3
 pytest-django==2.9.1
 invoke==0.13.0
 pprintpp==0.2.3
-pyfcm==1.0.0
+pyfcm==1.0.2

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -16,7 +16,6 @@ def test_fcm_basic(drop_messages):
         fcm.notify(drop1)
 
     data_message = {
-        'message': 'SGVsbG8gV29ybGQ=',
         'drop-id': 'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopo'
     }
     api.notify_topic_subscribers.assert_called_once_with(topic_name=drop1.drop_id, data_message=data_message)


### PR DESCRIPTION
While FCM messages in general are 4K in length, there is a neat sentence
buried in the error docs saying the limit is actually 2K in some cases,
notably topic messages.

For now we just remove the message body from the notification. This still
avoids the polling problem, although it generates more traffic than would be strictly
necessary (due to someone saving .5 memory pages).